### PR TITLE
Pass on errors from middleware

### DIFF
--- a/lib/middleware/index.js
+++ b/lib/middleware/index.js
@@ -34,9 +34,12 @@ Login.prototype.middleware = function(store, options) {
   var self = this;
 
   return function (req, res, next) {
-    self._passport.initialize()(req, res, function() {
-      self._passport.session()(req, res, function() {
-        self.sessionMiddleware(req, res, function() {
+    self._passport.initialize()(req, res, function(err) {
+      if(err) return next(err);
+      self._passport.session()(req, res, function(err) {
+        if(err) return next(err);
+        self.sessionMiddleware(req, res, function(err) {
+          if(err) return next(err);
           self.routesMiddleware(req, res, next);
         });
       });


### PR DESCRIPTION
This allows for throwing errors, such as a 403 error when a logged in user is not allowed to access a resource, in the middleware and hooks called from there, such as the request() hook. These errors should then be passed down to the error handling middleware.