### PR TITLE
Improvements and bugs hunting

### DIFF
--- a/components/login/index.html
+++ b/components/login/index.html
@@ -14,6 +14,6 @@
 
     <p class="text-danger">{{error}}</p>
 
-    <input type="submit" class="btn btn-primary btn-block" value="{{text || 'Login'}}" disabled="{{error || sending}}" />
+    <input type="submit" class="btn btn-primary btn-block btn-lg" value="{{text || 'Login'}}" disabled="{{error || sending}}" />
 
   </form>

--- a/lib/api/createUser.js
+++ b/lib/api/createUser.js
@@ -1,8 +1,12 @@
 module.exports = function(email, pwd, userData, done) {
-  var self = this;
+  var self    = this,
+      errors  = self.options.errors;
 
   self.register(email, pwd, userData, function (err, uID) {
-    if (err) { return done(err); }
+    if (err && (err.message !== errors.userExists)) {
+      return done(err);
+    }
+    
     if (self.options.confirmRegistration) {
       self.confirmEmail(uID, function (err) { return done(err); });
     } else {

--- a/lib/api/createUser.js
+++ b/lib/api/createUser.js
@@ -1,22 +1,30 @@
 module.exports = function(email, pwd, userData, done) {
-  var self    = this,
+  var cb      = done,
+      data    = userData,
+      self    = this,
       errors  = self.options.errors;
+  
+  // userData is optional
+  if (typeof data === 'function') {
+    cb = data;
+    data = {};
+  }
 
-  self.register(email, pwd, userData, function (err, uID) {
+  self.register(email, pwd, data, function (err, uID) {
     if (err && (err.message !== errors.userExists)) {
-      return done(err);
+      return cb(err);
     }
     
     if (self.options.confirmRegistration) {
       self.confirmEmail(uID.userId, function (err) {
         if (err && (err.message !== errors.alreadyConfirmed)) {
-          return done(err);
+          return cb(err);
         } else {
-          return done(null);
+          return cb(null);
         }
       });
     } else {
-      return done(null);
+      return cb(null);
     }
   });
 }

--- a/lib/api/createUser.js
+++ b/lib/api/createUser.js
@@ -8,7 +8,13 @@ module.exports = function(email, pwd, userData, done) {
     }
     
     if (self.options.confirmRegistration) {
-      self.confirmEmail(uID, function (err) { return done(err); });
+      self.confirmEmail(uID.userId, function (err) {
+        if (err && (err.message !== errors.alreadyConfirmed)) {
+          return done(err);
+        } else {
+          return done(null);
+        }
+      });
     } else {
       return done(null);
     }

--- a/lib/api/register.js
+++ b/lib/api/register.js
@@ -14,10 +14,14 @@ module.exports = function(email, password, userData, done) {
 
       // Create local profile
       var profile = {};
-      profile[self.options.emailChangeField] = {
-        email: email,
-        timestamp: +new Date()
-      };
+      if (self.options.confirmRegistration) {
+        profile[self.options.emailChangeField] = {
+          email: email,
+          timestamp: +new Date()
+        };
+      } else {
+        userData.email = email;
+      }
       profile[self.options.hashField] = hash;
 
       // Add the salt to the profile if we have one.

--- a/lib/crypt/scryptjs.js
+++ b/lib/crypt/scryptjs.js
@@ -2,7 +2,7 @@ var crypto = require('crypto'),
     scrypt = require('scryptsy');
 
 module.exports = function(saltLength) {
-  var N = 16384, r = 8, p = 1, lenBytes  = 64;
+  var N = 16384, r = 8, p = 1, lenBytes = 64;
   
   function scryptSalt() {
     return crypto.randomBytes(Math.ceil(saltLength / 2)).toString('hex').substring(0, saltLength);

--- a/lib/crypt/scryptjs.js
+++ b/lib/crypt/scryptjs.js
@@ -10,8 +10,8 @@ module.exports = function(saltLength) {
 
   return {
     compare: function(password, hash, salt, done) {
-      var p   = scrypt(password, salt, N, r, p, lenBytes),
-          eq  = (p.toString('hex') === hash);
+      var pass   = scrypt(password, salt, N, r, p, lenBytes),
+          eq  = (pass.toString('hex') === hash);
       
       done(null, eq);
     },


### PR DESCRIPTION
`register`:
When registering a user the `confirmRegistration` option was not checked.
With this patch if `confirmRegistration` is set to `false` the user is saved already registered, otherwise the same behaviour as beffore applies.

`createUser`:
(Lot's of these proposals are based on my needs, so let's discuss if the use of some flags to catch errors anyway would be more usefull ;) )
- When trying to create an already existing user go on and ignore the error
- If the user is already confirmed, go on and ignore the error
- `userData ` is now optional