### PR TITLE
Register req fix

### DIFF
--- a/lib/api/createUser.js
+++ b/lib/api/createUser.js
@@ -1,8 +1,14 @@
+function finalize (model, cb, cbParam) {
+  model.close();
+  return cb(cbParam);
+}
+
 module.exports = function(email, pwd, userData, done) {
   var cb      = done,
       data    = userData,
       self    = this,
-      errors  = self.options.errors;
+      errors  = self.options.errors,
+      model   = self.store.createModel();
   
   // userData is optional
   if (typeof data === 'function') {
@@ -10,22 +16,18 @@ module.exports = function(email, pwd, userData, done) {
     data = {};
   }
 
-  self.register(email, pwd, data, function (err, uID) {
+  self.register(model.id(), email, pwd, data, function (err, uID) {
     if (err && (err.message !== errors.userExists)) {
-      return cb(err);
+      return finalize(model, cb, err);
     }
     
-    if (self.options.confirmRegistration) {
-      self.confirmEmail(uID.userId, function (err) {
-        if (err && (err.message !== errors.alreadyConfirmed)) {
-          return cb(err);
-        } else {
-          return cb(null);
-        }
-      });
-    } else {
-      return cb(null);
-    }
+    self.confirmEmail((uID.userId ? uID.userId : uID), function (err) {
+      if (err && (err.message !== errors.alreadyConfirmed)) {
+        return finalize(model, cb, err);
+      } else {
+        return finalize(model, cb, null);
+      }
+    });
   });
 }
 

--- a/lib/api/register.js
+++ b/lib/api/register.js
@@ -1,4 +1,4 @@
-module.exports = function(req, email, password, userData, done) {
+module.exports = function(userId, email, password, userData, done) {
   var self = this;
 
   self.userExists(email, function(err, exist, user) {
@@ -25,7 +25,7 @@ module.exports = function(req, email, password, userData, done) {
       if (salt) { profile[self.options.saltField] = salt; }
 
       // Save user with profile
-      self.registerProvider(req.session.userId, self.options.localField, profile, userData, done);
+      self.registerProvider(userId, self.options.localField, profile, userData, done);
     });
   });
 };

--- a/lib/api/register.js
+++ b/lib/api/register.js
@@ -2,14 +2,14 @@ module.exports = function(req, email, password, userData, done) {
   var self = this;
 
   self.userExists(email, function(err, exist, user) {
-    if (err) return done(err);
+    if (err) { return done(err); }
 
     // Return error user allready exists
-    if (exist) return done(self.error('userExists'), {userId: user.id});
+    if (exist) { return done(self.error('userExists'), {userId: user.id}); }
 
     // Hash the password
     self.hash(password, function(err, hash, salt) {
-      if (err) return done(err);
+      if (err) { return done(err); }
 
       // Create local profile
       var profile = {};
@@ -22,7 +22,7 @@ module.exports = function(req, email, password, userData, done) {
       profile[self.options.hashField] = hash;
 
       // Add the salt to the profile if we have one.
-      if (salt) profile[self.options.saltField] = salt;
+      if (salt) { profile[self.options.saltField] = salt; }
 
       // Save user with profile
       self.registerProvider(req.session.userId, self.options.localField, profile, userData, done);

--- a/lib/api/register.js
+++ b/lib/api/register.js
@@ -1,6 +1,5 @@
 module.exports = function(req, email, password, userData, done) {
   var self = this;
-  var model = self.store.createModel();
 
   self.userExists(email, function(err, exist, user) {
     if (err) return done(err);

--- a/lib/middleware/routes/routeRegister.js
+++ b/lib/middleware/routes/routeRegister.js
@@ -4,7 +4,7 @@ module.exports = function(req, res, done) {
   self.parseRegisterRequest(req, res, function(err, email, password, userData) {
     if (err) return done(err);
 
-    self.register(req, email, password, userData, function(err, userId) {
+    self.register(req.session.userId, email, password, userData, function(err, userId) {
       if (err) return done(err);
 
       if (self.options.confirmRegistration) {


### PR DESCRIPTION
With commit 777dd10f3e9be0fdba2f93b06de518de65d12b8e `createUser` was broken because it was calling `register` without the first parameter `req`.
With the occasion I refactored the first param of `register` which is not a request anymore, but it's a userId instead since a complete request object is not needed anyway.
In this way inside
- `createUser` creates a new user id calling `model.id()` and passing it a `register`
- I hope this breaks as less code as possible