### PR TITLE
Add '/registerAdmin' route

### DIFF
--- a/lib/defaultOptions.js
+++ b/lib/defaultOptions.js
@@ -17,6 +17,7 @@ module.exports = {
     login: 'login',
     logout: 'logout',
     register: 'register',
+    registerAdmin: 'registerAdmin',
     confirmregistration: 'confirmregistration',
     confirmemailchange: 'confirmemailchange'
   },

--- a/lib/middleware/routes/index.js
+++ b/lib/middleware/routes/index.js
@@ -7,6 +7,7 @@ Login.prototype.routeResetPassword = require('./routeResetPassword');
 Login.prototype.routeLogin = require('./routeLogin');
 Login.prototype.routeLogout = require('./routeLogout');
 Login.prototype.routeRegister = require('./routeRegister');
+Login.prototype.routeRegisterAdmin = require('./routeRegisterAdmin');
 Login.prototype.routeConfirmRegistration = require('./routeConfirmRegistration');
 Login.prototype.routeConfirmEmailChange = require('./routeConfirmEmailChange');
 Login.prototype.routeHandleStrategies = require('./routeHandleStrategies');

--- a/lib/middleware/routes/routeRegisterAdmin.js
+++ b/lib/middleware/routes/routeRegisterAdmin.js
@@ -1,0 +1,32 @@
+module.exports = function(req, res, done) {
+  var self = this;
+
+  self.parseRegisterRequest(req, res, function(err, email, password, userData) {
+    if (err) return done(err);
+
+    // Register new id for new user, instead of using session.userId
+    var model = req.getModel();
+    var newUserId = model.id();
+
+    self.register(newUserId, email, password, userData, function(err, newUserId) {
+      if (err) return done(err);
+
+      if (self.options.confirmRegistration) {
+        self.sendRegistrationConfirmation(newUserId, email, password, userData, function(err){
+          if (err) return done(err);
+          done(null, {userId: newUserId});
+        });
+      } else {
+        self.sendRegistrationInfo(newUserId, email, password, userData, function(err){
+          if (err) return done(err);
+
+          self.confirmEmail(newUserId, function(err) {
+            if (err) return done(err);
+            // We don't login here, but trigger done here regardless
+            done(null, {userId: newUserId});
+          });
+        });
+      }
+    });
+  });
+};

--- a/lib/middleware/routesMiddleware.js
+++ b/lib/middleware/routesMiddleware.js
@@ -20,6 +20,7 @@ module.exports = function(req, res, next) {
     case urls.login: return self.routeLogin(req, res, done);
     case urls.logout: return self.routeLogout(req, res, done);
     case urls.register: return self.routeRegister(req, res, done);
+    case urls.registerAdmin: return self.routeRegisterAdmin(req, res, done);
     case urls.confirmregistration: return self.routeConfirmRegistration(req, res, done);
     case urls.confirmemailchange: return self.routeConfirmEmailChange(req, res, done);
     // Catch /auth/:provider and /auth/:provider/callback routes


### PR DESCRIPTION
Adds a new /registerAdmin route which allows someone who is logged in to create new users (i.e. an administrator). This is achieved by not using the session's userId for the new user, but rather generating a new one each time the route is triggered.

The code is tested and it works, but feel free to modify it if it doesn't conform to the official code style. Also, you could rename the route from 'registerAdmin' to something more appropriate if you wish.
